### PR TITLE
Add SIMD algorithm

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.1.0"
 authors = ["Sebastian Dröge <sebastian@centricular.com>"]
 
 [dependencies]
-faster = { git = "https://github.com/Osveron/faster", branch = "zip" }
+faster = { git = "https://github.com/AdamNiederer/faster", branch = "master" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,4 @@ version = "0.1.0"
 authors = ["Sebastian Dröge <sebastian@centricular.com>"]
 
 [dependencies]
+faster = { git = "https://github.com/Osveron/faster", branch = "zip" }


### PR DESCRIPTION
Hey, I saw your mention of faster in your blog post. Here's an algorithm that works well with it.

This only has a commanding performance lead in a pre-release version of faster, and only when compiled with "-C target-cpu=nehalem" because of some codegen issues. On the currently published version, it's nearly 5x slower than the scalar algorithm. I'll send another PR bumping the version once a more stable version is on crates.io

```
test tests::bench_chunks_1920x1080_asserts           ... bench:   5,002,517 ns/iter (+/- 35,872)
test tests::bench_chunks_1920x1080_asserts_2         ... bench:   4,157,308 ns/iter (+/- 20,554)
test tests::bench_chunks_1920x1080_iter_sum          ... bench:  13,477,917 ns/iter (+/- 52,999)
test tests::bench_chunks_1920x1080_iter_sum_2        ... bench:  12,375,261 ns/iter (+/- 52,677)
test tests::bench_chunks_1920x1080_no_asserts        ... bench:   4,626,590 ns/iter (+/- 32,872)
test tests::bench_chunks_1920x1080_no_asserts_faster ... bench:     626,222 ns/iter (+/- 65,893)
test tests::bench_exact_chunks_1920x1080             ... bench:   2,129,565 ns/iter (+/- 55,395)
test tests::bench_split_at_1920x1080                 ... bench:   2,113,478 ns/iter (+/- 53,464)
```